### PR TITLE
Specify as specific versions as possible of used actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,13 @@ jobs:
           - { py: "3.9", django: "40" }
           - { py: "3.9", django: "32" }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.1.2
+      - uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.12"
       - run: python -m pip install tox
       - name: Setup python for test ${{ matrix.py }} - django${{ matrix.django }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: ${{ matrix.py }}
       - name: Setup test suite
@@ -64,7 +64,7 @@ jobs:
       - name: Run test suite
         run: tox -e django${{ matrix.django }}-py${{ matrix.py }} --skip-pkg-install
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.2.0
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
@@ -76,13 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Test django_main
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.1.2
+      - uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.12"
       - run: python -m pip install tox
       - name: Setup python for test 3.12 - django main branch
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.12"
       - name: Setup test suite
@@ -93,8 +93,8 @@ jobs:
   static-typing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.1.2
+      - uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.9'
       - run: pip install tox
@@ -104,8 +104,8 @@ jobs:
   check-migrations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.1.2
+      - uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.9'
       - run: pip install tox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,12 @@ jobs:
       id-token: write
     steps:
       - name: Setup python to build package
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.12"
       - name: Install build
         run: python -m pip install build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.2
         with:
           fetch-depth: 0
       - name: Build package


### PR DESCRIPTION
In case any of the actions don't change their major only tag. This will for example allow us to receive minor and patch versions of e.g. `actions/checkout`