### PR TITLE
Split up `ci.yaml` workflow in multiple files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  COLUMNS: "120"
+  FORCE_COLOR: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  lint:
+    name: Static analysis
+    uses: less-action/reusables/.github/workflows/pre-commit.yaml@v10
+    with:
+      python-version: "3.10"
+
+  check-build:
+    name: Check packaging
+    uses: less-action/reusables/.github/workflows/python-test-build.yaml@v10

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,22 @@
-name: CI
+name: Test
 
 on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/test.yaml'
+      - 'src/**'
+      - 'test/**'
+      - 'pyproject.toml'
+      - 'tox.ini'
   pull_request:
+    paths:
+      - '.github/workflows/test.yaml'
+      - 'src/**'
+      - 'test/**'
+      - 'pyproject.toml'
+      - 'tox.ini'
   schedule:
     - cron: '33 16 * * 3'  # https://crontab.guru/#33_16_*_*_3
 
@@ -18,16 +30,6 @@ env:
   PYTHONUNBUFFERED: "1"
 
 jobs:
-  lint:
-    name: Lint
-    uses: less-action/reusables/.github/workflows/pre-commit.yaml@v10
-    with:
-      python-version: "3.10"
-
-  check-build:
-    name: Check packaging
-    uses: less-action/reusables/.github/workflows/python-test-build.yaml@v10
-
   test:
     name: Test django${{ matrix.django }}-py${{ matrix.py }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align=center>Django ChoiceField</h1>
 
 <p align=center>
-    <a href="https://github.com/flaeppe/django-choicefield/actions?query=workflow%3ACI+branch%3Amain"><img src="https://github.com/flaeppe/django-choicefield/actions/workflows/ci.yaml/badge.svg?branch=main" alt="CI workflow Status"></a>
+    <a href="https://github.com/flaeppe/django-choicefield/actions?query=workflow%3ATest+branch%3Amain"><img src="https://github.com/flaeppe/django-choicefield/actions/workflows/test.yaml/badge.svg?branch=main" alt="Test workflow Status"></a>
     <a href="https://codecov.io/gh/flaeppe/django-choicefield" > <img src="https://codecov.io/gh/flaeppe/django-choicefield/branch/main/graph/badge.svg?token=SV7YKU958R"/> </a>
     <a href="https://pypi.org/project/django-choicefield/"><img src="https://img.shields.io/pypi/v/django-choicefield.svg?color=informational&label=PyPI" alt="PyPI Package"></a>
     <a href="https://pypi.org/project/django-choicefield/"><img src="https://img.shields.io/pypi/pyversions/django-choicefield.svg?color=informational&label=Python" alt="Python versions"></a>


### PR DESCRIPTION
Introduce a 'Lint' workflow and a 'Test' workflow and configure the 'Test' workflow to only run python/runtime related code changes